### PR TITLE
Improve styling and loading indicator

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="8" fill="currentColor"/>
+  <path d="M20 22h24v4H20zM20 30h24v4H20zM20 38h24v4H20z" fill="#fff"/>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #fff;
+  --foreground: #000;
 }
 
 @theme inline {
@@ -14,13 +14,13 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #000;
+    --foreground: #fff;
   }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Header from "@/components/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Header />
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -50,7 +50,10 @@ export default function Home() {
 
   return (
     <div className="flex items-center justify-center min-h-screen p-6 bg-background text-foreground">
-      <form onSubmit={handleSubmit} className="space-y-4 w-full max-w-md">
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-4 w-full max-w-md bg-background border border-foreground p-6 rounded-lg shadow-lg"
+      >
         <textarea
           className="w-full border rounded-md p-2 bg-transparent"
           rows={3}
@@ -78,8 +81,11 @@ export default function Home() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-foreground text-background py-2 rounded-md hover:opacity-80 disabled:opacity-50"
+          className="w-full bg-foreground text-background py-2 rounded-md hover:opacity-80 disabled:opacity-50 flex items-center justify-center gap-2"
         >
+          {loading && (
+            <span className="animate-spin rounded-full h-4 w-4 border-2 border-background border-t-transparent" />
+          )}
           {loading ? "Translating..." : "Translate"}
         </button>
         {error && <p className="text-red-500 text-sm">{error}</p>}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,10 @@
+import Image from "next/image";
+
+export default function Header() {
+  return (
+    <header className="flex items-center gap-3 p-4 border-b border-foreground">
+      <Image src="/logo.svg" alt="eSports Translatio" width={32} height={32} />
+      <h1 className="text-2xl font-bold">eSports Translatio</h1>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- create a simple logo and header component
- apply monochrome theme
- style form container and add spinner inside the button

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_68544c61b5608331bc463227e660417f