### PR TITLE
Allow manual OpenAI key input

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ A powerful JSON translation tool designed for esports and gaming applications. B
 npm install
 ```
 
-2. Set up environment variables:
+2. (Optional) Set up environment variables:
 ```bash
 # Create a .env.local file in the root directory
 echo "OPENAI_API_KEY=your_openai_api_key_here" > .env.local
 ```
+You can also enter the API key directly in the web interface if you prefer not to store it locally.
 
 3. Run the development server:
 ```bash
@@ -61,11 +62,12 @@ Upload an i18n JSON file, describe your app, and pick a target language. The tra
 
 1. Push your code to GitHub/GitLab/Bitbucket
 2. Connect your repository to Vercel
-3. **Add environment variable in Vercel dashboard:**
+3. **(Optional) Add environment variable in Vercel dashboard:**
    - Go to your project settings
    - Click "Environment Variables"
    - Add `OPENAI_API_KEY` with your OpenAI API key
    - Set it for "Production", "Preview", and "Development"
+   - Skip this if you prefer entering the key in the app
 4. Deploy!
 
 The `vercel.json` configuration file is set up for:
@@ -74,7 +76,7 @@ The `vercel.json` configuration file is set up for:
 
 ### Manual Deployment
 
-Make sure to set the following environment variables:
+Make sure to set the following environment variables (or provide the key in the UI):
 - `OPENAI_API_KEY`: Your OpenAI API key
 - `NODE_ENV`: Set to `production`
 
@@ -126,7 +128,7 @@ Translates a JSON file to the specified language.
 - Large files (500+ keys): Recommend Pro plan or local development
 
 **Troubleshooting:**
-1. Check that your OpenAI API key is properly set in Vercel dashboard
+1. Check that your OpenAI API key is provided (either in the Vercel dashboard or via the form)
 2. Monitor Vercel function logs - you'll see "Processing chunk X/Y" progress
 3. Each chunk should complete in 3-5 seconds
 4. For very large files on Hobby plan, consider upgrading to Pro or use local development

--- a/src/app/api/translate/route.ts
+++ b/src/app/api/translate/route.ts
@@ -12,19 +12,20 @@ const MAX_RETRIES = 0; // No retries to save time
 
 export async function POST(request: Request) {
   try {
-    const { json, language, prompt } = await request.json();
+    const { json, language, prompt, apiKey } = await request.json();
     
     // This API now expects a single SMALL chunk, not full JSON
 
-    if (!process.env.OPENAI_API_KEY) {
+    const resolvedKey = apiKey || process.env.OPENAI_API_KEY;
+    if (!resolvedKey) {
       return NextResponse.json(
-        { error: "Missing OPENAI_API_KEY" },
-        { status: 500 }
+        { error: "Missing OpenAI API key" },
+        { status: 400 }
       );
     }
 
-    const openai = new OpenAI({ 
-      apiKey: process.env.OPENAI_API_KEY,
+    const openai = new OpenAI({
+      apiKey: resolvedKey,
       timeout: REQUEST_TIMEOUT,
     });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -262,6 +262,7 @@ export default function Home() {
   const [error, setError] = useState("");
   const [isMounted, setIsMounted] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
+  const [apiKey, setApiKey] = useState("");
   const [progress, setProgress] = useState({ current: 0, total: 0 });
   const [success, setSuccess] = useState(false);
 
@@ -354,10 +355,11 @@ export default function Home() {
           const res = await fetch("/api/translate", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ 
-              json: JSON.stringify(chunk), 
-              language, 
-              prompt 
+            body: JSON.stringify({
+              json: JSON.stringify(chunk),
+              language,
+              prompt,
+              apiKey
             }),
           });
           
@@ -464,6 +466,20 @@ export default function Home() {
             placeholder="Describe your app..."
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="api-key" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+            OpenAI API Key:
+          </label>
+          <input
+            id="api-key"
+            type="password"
+            className="w-full border rounded-md p-3 bg-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 transition-all"
+            placeholder="sk-..."
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
           />
         </div>
         


### PR DESCRIPTION
## Summary
- make OPENAI key optional for Vercel and local runs
- allow providing API key from the UI
- use provided key in API route

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_685a6bb673c88331b405655c626d510c